### PR TITLE
Docker multistage build to reduce image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,7 @@
 node_modules
 dist
+docs
+.vscode
+
+.gitignore
+.gitbook.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+ARG NODE_VERSION="12.2.0"
+FROM library/node:${NODE_VERSION} AS development
+
+ENV NODE_ENV "development"
+WORKDIR /usr/src/freshlytics
+
+COPY package*.json ./
+RUN npm install --no-optional
+
+COPY . .
+
+CMD ["npm", "run", "dev"]
+EXPOSE 3000/tcp 3001/tcp
+
+FROM development AS builder
+
+ENV NODE_ENV "production"
+RUN npm run build
+
+FROM library/node:${NODE_VERSION}-slim AS production
+
+ENV NODE_ENV "production"
+WORKDIR /usr/src/freshlytics
+
+ENV BUILD_DEPS="python2.7 make g++"
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+    ${BUILD_DEPS} && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/src/freshlytics/package*.json ./
+RUN PYTHON=/usr/bin/python2.7 \
+  npm install --production --no-optional && \
+  apt-get purge -y ${BUILD_DEPS} && \
+  apt-get autoremove -y
+
+COPY --from=builder /usr/src/freshlytics/dist ./dist/
+RUN chown -R node:node .
+
+USER node
+
+CMD ["npm", "start"]
+EXPOSE 3000/tcp 3001/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG NODE_VERSION="12.2.0"
-FROM library/node:${NODE_VERSION} AS development
+FROM node:${NODE_VERSION} AS development
 
 ENV NODE_ENV "development"
 WORKDIR /usr/src/freshlytics
@@ -17,7 +17,7 @@ FROM development AS builder
 ENV NODE_ENV "production"
 RUN npm run build
 
-FROM library/node:${NODE_VERSION}-slim AS production
+FROM node:${NODE_VERSION}-slim AS production
 
 ENV NODE_ENV "production"
 WORKDIR /usr/src/freshlytics

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ RUN chown -R node:node .
 USER node
 
 CMD ["npm", "start"]
-EXPOSE 3000/tcp 3001/tcp
+EXPOSE 3001/tcp

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,0 @@
-FROM node:12.2.0
-
-WORKDIR /app
-
-COPY . .
-
-RUN npm install --no-optional

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,9 +1,0 @@
-FROM node:12.2.0
-
-WORKDIR /app
-
-COPY . .
-
-RUN npm install --no-optional
-
-RUN npm run build

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,19 +1,18 @@
-version: "3"
+version: "3.4"
 
 services:
   freshlytics:
+    image: freshlytics/freshlytics:development
     build:
-      context: .
-      dockerfile: Dockerfile.dev
+      target: development
     ports:
       - "3000:3000"
       - "3001:3001"
     volumes:
-      - ./src/client:/app/src/client
-      - ./src/server:/app/src/server
+      - ./src/client:/usr/src/freshlytics/client:rw
+      - ./src/server:/usr/src/freshlytics/server:rw
     environment:
       - NODE_ENV=development
-    command: npm run dev
 
   db:
     ports:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,8 +11,6 @@ services:
     volumes:
       - ./src/client:/usr/src/freshlytics/client:rw
       - ./src/server:/usr/src/freshlytics/server:rw
-    environment:
-      - NODE_ENV=development
 
   db:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
-version: "3"
+version: "3.4"
 
 services:
   freshlytics:
-    image: freshlytics/freshlytics
-    # build:
-    #   context: .
-    #   dockerfile: Dockerfile.prod
+    image: freshlytics/freshlytics:latest
+    build:
+      context:    .
+      dockerfile: Dockerfile
+      target:     production
     ports:
       - "80:3001"
     environment:
       - DATABASE_URL=postgres://postgres:hunter2@db:5432/freshlytics
       - NODE_ENV=production
-    command: npm start
     depends_on:
       - db
 
@@ -21,4 +21,7 @@ services:
       - POSTGRES_PASSWORD=hunter2
       - POSTGRES_DB=freshlytics
     volumes:
-      - ./tmp/db:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql/data:rw
+
+volumes:
+  db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - "80:3001"
     environment:
       - DATABASE_URL=postgres://postgres:hunter2@db:5432/freshlytics
-      - NODE_ENV=production
     depends_on:
       - db
 


### PR DESCRIPTION
Hi, I've been testing out freshlytics for a bit and it's pretty cool. Thanks for making it!
Saw you had an issue opened to reduce the size of the freshlytics docker image and thought I'd help out.

Adding multistage builds and only copying over the built files doesn't reduce the size all that much (since the production node_modules are still required at runtime).

So instead, to achieve your goal of reducing the image size, we can use the slim tag variant of the node base image and get it down to 421MB (from >1GB).

We can further reduce the image size (probably to under 100MB) by using the alpine tag variant, but using alpine images can have some weirdness sometimes, so I'll probably do some tests before submitting a PR for it.

Let me know what you think.

resolves #3 